### PR TITLE
docs: add mise support and clean up documentation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,6 +16,6 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: asdf_plugin_test
-        uses: asdf-vm/actions/plugin-test@v3
+        uses: asdf-vm/actions/plugin-test@v4
         with:
           command: git --version

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-TODO: INSERT YOUR NAME  COPYRIGHT YEAR (if applicable to your license)
+asdf-git-worktree-wrapper
 
                                  Apache License
                            Version 2.0, January 2004

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # asdf-git-worktree-wrapper [![Build](https://github.com/kedwards/asdf-git-worktree-wrapper/actions/workflows/build.yml/badge.svg)](https://github.com/kedwards/asdf-git-worktree-wrapper/actions/workflows/build.yml) [![Lint](https://github.com/kedwards/asdf-git-worktree-wrapper/actions/workflows/lint.yml/badge.svg)](https://github.com/kedwards/asdf-git-worktree-wrapper/actions/workflows/lint.yml)
 
-[git-worktree-wrapper](https://github.com/kedwards/git-worktree-wrapper) plugin for the [asdf version manager](https://asdf-vm.com).
+[git-worktree-wrapper](https://github.com/kedwards/git-worktree-wrapper) plugin for the [asdf version manager](https://asdf-vm.com)
 
 </div>
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,8 @@ asdf plugin add git-worktree-wrapper https://github.com/kedwards/asdf-git-worktr
 ```
 
 ```shell
-mise use git-worktree-wrapper
+mise plugin addt-worktreewrapper https://github.com/kedwards/asdf-git-worktree-wrapper.git 
+mise use --global git-worktree-wrapper
 ```
 
 git-worktree-wrapper:

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # asdf-git-worktree-wrapper [![Build](https://github.com/kedwards/asdf-git-worktree-wrapper/actions/workflows/build.yml/badge.svg)](https://github.com/kedwards/asdf-git-worktree-wrapper/actions/workflows/build.yml) [![Lint](https://github.com/kedwards/asdf-git-worktree-wrapper/actions/workflows/lint.yml/badge.svg)](https://github.com/kedwards/asdf-git-worktree-wrapper/actions/workflows/lint.yml)
 
-[git-worktree-wrapper](https://github.com/kedwards/git-worktree-wrapper) plugin for the [asdf version manager](https://asdf-vm.com)
+[git-worktree-wrapper](https://github.com/kedwards/git-worktree-wrapper) plugin for the [asdf version manager](https://asdf-vm.com) an/or [mise](https://mise.jdx.dev).
 
 </div>
 
@@ -15,10 +15,7 @@
 
 # Dependencies
 
-**TODO: adapt this section**
-
 - `bash`, `curl`, `tar`, and [POSIX utilities](https://pubs.opengroup.org/onlinepubs/9699919799/idx/utilities.html).
-- `SOME_ENV_VAR`: set this environment variable in your shell config to load the correct version of tool x.
 
 # Install
 
@@ -28,6 +25,10 @@ Plugin:
 asdf plugin add git-worktree-wrapper
 # or
 asdf plugin add git-worktree-wrapper https://github.com/kedwards/asdf-git-worktree-wrapper.git
+```
+
+```shell
+mise use git-worktree-wrapper
 ```
 
 git-worktree-wrapper:
@@ -46,8 +47,7 @@ asdf global git-worktree-wrapper latest
 git-worktree-wrapper --help
 ```
 
-Check [asdf](https://github.com/asdf-vm/asdf) readme for more instructions on how to
-install & manage versions.
+Check [asdf](https://github.com/asdf-vm/asdf) or [mise](https://mise.jdx.dev/walkthrough.html#installing-dev-tools) readme for more instructions on how to install & manage versions.
 
 # Contributing
 
@@ -57,4 +57,4 @@ Contributions of any kind welcome! See the [contributing guide](contributing.md)
 
 # License
 
-See [LICENSE](LICENSE) © [Kevin Edwards](https://github.com/kedwards/)
+See [LICENSE](LICENSE) ©

--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 # TODO: Ensure this is the correct GitHub homepage where releases can be downloaded for git-worktree-wrapper.
-GH_REPO="https://github.com/lu0/git-worktree-wrapper"
+GH_REPO="https://github.com/kevinedwards/git-worktree-wrapper"
 TOOL_NAME="git-worktree-wrapper"
 # TOOL_TEST="git --version"
 


### PR DESCRIPTION
- Add mise version manager installation instructions and references
- Update repository URL to point to correct git-worktree-wrapper repo
- Clean up TODO items and placeholder text in LICENSE and documentation
- Improve README clarity and formatting